### PR TITLE
Make it possible to attach a PayloadProcessor to process model predictions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,17 +57,17 @@
     <!--suppress UnresolvedMavenProperty -->
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
-    <grpc-version>1.50.2</grpc-version>
-    <netty-version>4.1.84.Final</netty-version>
+    <grpc-version>1.51.1</grpc-version>
+    <netty-version>4.1.86.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>
     <etcd-java-version>0.0.22</etcd-java-version>
-    <protobuf-version>3.21.9</protobuf-version>
-    <annotation-version>9.0.68</annotation-version>
+    <protobuf-version>3.21.12</protobuf-version>
+    <annotation-version>9.0.70</annotation-version>
     <guava-version>31.1-jre</guava-version>
-    <jackson-databind-version>2.13.4.2</jackson-databind-version>
+    <jackson-databind-version>2.14.1</jackson-databind-version>
     <gson-version>2.10</gson-version>
-    <thrift-version>0.16.0</thrift-version>
+    <thrift-version>0.17.0</thrift-version>
     <eclipse-collections-version>11.1.0</eclipse-collections-version>
     <log4j2-version>2.19.0</log4j2-version>
     <slf4j-version>1.7.36</slf4j-version>

--- a/src/main/java/com/ibm/watson/modelmesh/Metrics.java
+++ b/src/main/java/com/ibm/watson/modelmesh/Metrics.java
@@ -170,7 +170,7 @@ interface Metrics extends AutoCloseable {
                     }
                     break;
                 case "fq_names":
-                    shortNames = "true".equalsIgnoreCase(ent.getValue());
+                    shortNames = !"true".equalsIgnoreCase(ent.getValue());
                     break;
                 case "scheme":
                     if ("http".equals(ent.getValue())) {
@@ -395,7 +395,7 @@ interface Metrics extends AutoCloseable {
                     legacy = "true".equalsIgnoreCase(ent.getValue());
                     break;
                 case "fq_names":
-                    shortNames = "true".equalsIgnoreCase(ent.getValue());
+                    shortNames = !"true".equalsIgnoreCase(ent.getValue());
                     break;
                 default:
                     throw new Exception("Unrecognized metrics config parameter: " + ent.getKey());

--- a/src/main/java/com/ibm/watson/modelmesh/ModelCacheUnloadBufManager.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelCacheUnloadBufManager.java
@@ -95,6 +95,15 @@ final class ModelCacheUnloadBufManager {
         return UNLOAD_BUFF.getWeight();
     }
 
+    // For instrumentation/diagnostics only
+    int getTotalUnloadingWeight() {
+        return totalUnloadingWeight;
+    }
+    // For instrumentation/diagnostics only
+    long getTotalModelCacheOccupancy() {
+        return totalModelCacheOccupancy;
+    }
+
     void removeUnloadBufferEntry(Map<String, ?> entries) { //TODO TBD maybe static
         entries.remove(UNLOAD_BUFFER_CACHE_KEY);
     }

--- a/src/main/java/com/ibm/watson/modelmesh/processor/AsyncPayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/processor/AsyncPayloadProcessor.java
@@ -1,0 +1,35 @@
+package com.ibm.watson.modelmesh.processor;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class AsyncPayloadProcessor implements PayloadProcessor {
+
+    private final PayloadProcessor delegate;
+
+    private final Queue<Payload> payloads = new ConcurrentLinkedQueue<>();
+
+    public AsyncPayloadProcessor(PayloadProcessor delegate) {
+        this.delegate = delegate;
+        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+        scheduler.scheduleWithFixedDelay(() -> {
+            Payload p;
+            while ((p = payloads.poll()) != null) {
+                delegate.process(p);
+            }
+        }, 0, 1, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public void process(Payload payload) {
+        payloads.add(payload);
+    }
+}

--- a/src/main/java/com/ibm/watson/modelmesh/processor/AsyncPayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/processor/AsyncPayloadProcessor.java
@@ -20,7 +20,7 @@ public class AsyncPayloadProcessor implements PayloadProcessor {
             while ((p = payloads.poll()) != null) {
                 delegate.process(p);
             }
-        }, 0, 1, TimeUnit.SECONDS);
+        }, 0, 1, TimeUnit.MINUTES);
     }
 
     @Override

--- a/src/main/java/com/ibm/watson/modelmesh/processor/CompositePayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/processor/CompositePayloadProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ibm.watson.modelmesh.processor;
+
+import java.util.List;
+
+public class CompositePayloadProcessor implements PayloadProcessor {
+
+    private final List<PayloadProcessor> delegates;
+
+    public CompositePayloadProcessor(List<PayloadProcessor> delegates) {
+        this.delegates = delegates;
+    }
+
+    @Override
+    public String getName() {
+        return "composite";
+    }
+
+    @Override
+    public void process(Payload payload) {
+        for (PayloadProcessor processor : this.delegates) {
+            processor.process(payload);
+        }
+    }
+}

--- a/src/main/java/com/ibm/watson/modelmesh/processor/LoggingPayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/processor/LoggingPayloadProcessor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ibm.watson.modelmesh.processor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggingPayloadProcessor implements PayloadProcessor {
+
+    private final Logger LOG = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public String getName() {
+        return "logger";
+    }
+
+    @Override
+    public void process(Payload payload) {
+        LOG.info("Payload: {}", payload);
+    }
+}

--- a/src/main/java/com/ibm/watson/modelmesh/processor/MatchingPayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/processor/MatchingPayloadProcessor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ibm.watson.modelmesh.processor;
+
+public class MatchingPayloadProcessor implements PayloadProcessor {
+
+    private final PayloadProcessor delegate;
+
+    private final String methodName;
+
+    private final String modelId;
+
+    public MatchingPayloadProcessor(PayloadProcessor delegate, String methodName, String modelId) {
+        this.delegate = delegate;
+        this.methodName = methodName != null && methodName.equals("*") ? null : methodName;
+        this.modelId = modelId != null && modelId.equals("*") ? null : modelId;
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public void process(Payload payload) {
+        boolean methodMatches = true;
+        if (this.methodName != null && this.methodName.length() > 0) {
+            methodMatches = this.methodName.equals(payload.getMethod().getName()) ||
+                    this.methodName.equals(payload.getRemoteMethod().getName());
+        }
+        boolean modelIdMatches = true;
+        if (this.modelId != null && this.modelId.length() > 0) {
+            modelIdMatches = this.modelId.equals(payload.getModelId());
+        }
+        if (modelIdMatches && methodMatches) {
+            delegate.process(payload);
+        }
+    }
+}

--- a/src/main/java/com/ibm/watson/modelmesh/processor/Payload.java
+++ b/src/main/java/com/ibm/watson/modelmesh/processor/Payload.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ibm.watson.modelmesh.processor;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+public class Payload {
+
+    private final String modelId;
+
+    private final Method method;
+
+    private final Method remoteMethod;
+
+    private final Object[] gRPCArgs;
+
+    private final Object modelResponse;
+
+    public Payload(String modelId, Method method, Method remoteMethod, Object[] gRPCArgs, Object modelResponse) {
+        this.modelId = modelId;
+        this.method = method;
+        this.remoteMethod = remoteMethod;
+        this.gRPCArgs = gRPCArgs;
+        this.modelResponse = modelResponse;
+    }
+
+    public String getModelId() {
+        return modelId;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public Method getRemoteMethod() {
+        return remoteMethod;
+    }
+
+    public Object[] getGRPCArgs() {
+        return gRPCArgs;
+    }
+
+    public Object getModelResponse() {
+        return modelResponse;
+    }
+
+    @Override
+    public String toString() {
+        return "Payload{" +
+                "modelId='" + modelId + '\'' +
+                ", method=" + method +
+                ", remoteMethod=" + remoteMethod +
+                ", gRPCArgs=" + Arrays.toString(gRPCArgs) +
+                ", modelResponse=" + modelResponse +
+                '}';
+    }
+}

--- a/src/main/java/com/ibm/watson/modelmesh/processor/PayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/processor/PayloadProcessor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ibm.watson.modelmesh.processor;
+
+public interface PayloadProcessor {
+
+    String getName();
+
+    void process(Payload payload);
+}

--- a/src/main/java/com/ibm/watson/modelmesh/processor/README.md
+++ b/src/main/java/com/ibm/watson/modelmesh/processor/README.md
@@ -1,0 +1,29 @@
+Processing model-mesh payloads
+=============================
+
+In `model-mesh` the id of a given model, the method being called with its inputs and associated outputs form the `Payload`.
+A `PayloadProcessor` is responsible for processing such `Payloads` for models served by `model-mesh`.
+
+Reasonable examples of `PayloadProcessors` include loggers of model predictions, data sinks for visualization, model quality assessment or monitoring purposes.
+
+A `PayloadProcessor` can be configured to only look at payloads that are consumed and produced by certain models, or payloads containing certain headers, etc.
+This configuration is performed at `ModelMesh` instance level.
+Multiple `PayloadProcessors` can be configured per each `ModelMesh` instance.
+
+Implementations of `PayloadProcessors` can care about only specific portions of the payload (e.g., model inputs, model outputs, metadata, specific headers, etc.).
+
+A `PayloadProcessor` sees input data like the one in this example:
+```text
+[mmesh.ExamplePredictor/predict, Metadata(content-type=application/grpc,user-agent=grpc-java-netty/1.51.1,mm-model-id=myModel,another-custom-header=custom-value,grpc-accept-encoding=gzip,grpc-timeout=1999774u), CompositeByteBuf(ridx: 0, widx: 2000004, cap: 2000004, components=147)
+```
+
+A `PayloadProcessor` sees output data as `ByteBuf` like the one in this example:
+```text
+java.nio.HeapByteBuffer[pos=0 lim=65 cap=65]
+```
+
+A `PayloadProcessor` can be configured by means of a comma separated string of URIs.
+In a URI like `logger://pytorch1234?predict`: 
+* the scheme represents the type of processor, e.g., `logger`
+* the authority represents the model id to observe, e.g., `pytorch1234` 
+* the query represents the method to observe, e.g., `predict`


### PR DESCRIPTION
#### Motivation
This PR seeks to address the _model-mesh_ side of https://github.com/kserve/modelmesh-serving/issues/284.

#### Modifications
It provides a `PayloadProcessor` interface. `PayloadProcessors` are picked by `ModelMesh` at startup and predictions (`Payloads`) are processed asynchronously at fixed timing.
A first _logger_ implementation allows to log `Payloads` (at _info_ level).

#### Result
A SPI for post processing model of predictions.
