### PR TITLE
Disable github action for main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: Build
 on:
   pull_request:
     branches:
-      - main
-      - "release-[0-9].[0-9]+"
+      - "release-[0-9].[0-9]+ "
     paths-ignore:
       - "**.md"
   push:


### PR DESCRIPTION
#### Motivation
Disable github action for main branch because we are using openshift-ci for PR checks

#### Modifications


#### Result
