### PR TITLE
[RHODS-12555] - CVE-2023-44487

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
     <grpc-version>1.57.2</grpc-version>
-    <netty-version>4.1.96.Final</netty-version>
+    <netty-version>4.1.100.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>
     <etcd-java-version>0.0.22</etcd-java-version>


### PR DESCRIPTION
Community: https://github.com/kserve/modelmesh/pull/114

#### Motivation
Address the HTTP/2 CVE

#### Modifications
Bump netty version to: 4.1.100.Final

#### Result
Snyk scan:
```
$ snyk test
...
Tested 66 dependencies for known issues, found 3 issues, 3 vulnerable paths.


Issues with no direct upgrade or patch:
  ✗ Improper Certificate Validation [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-1042268] in io.netty:netty-handler@4.1.100.Final
    introduced by com.ibm.utils.litelinks:litelinks-core@1.7.2 > io.netty:netty-handler@4.1.100.Final
  No upgrade or patch available
  ✗ Authorization Bypass Through User-Controlled Key [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEZOOKEEPER-5961102] in org.apache.zookeeper:zookeeper@3.5.9
    introduced by com.ibm.utils.litelinks:litelinks-core@1.7.2 > org.apache.zookeeper:zookeeper@3.5.9
  This issue was fixed in versions: 3.7.2, 3.8.3, 3.9.1
  ✗ Information Exposure [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-5771339] in org.bouncycastle:bcprov-jdk15on@1.70
    introduced by org.bouncycastle:bcpkix-jdk15on@1.70 > org.bouncycastle:bcprov-jdk15on@1.70
  No upgrade or patch available

```

