### PR TITLE
RHOAIENG-4963: ModelMesh should support TLS in payload processors

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
@@ -23,6 +23,8 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.grpc.Metadata;
@@ -42,11 +44,27 @@ public class RemotePayloadProcessor implements PayloadProcessor {
 
     private final URI uri;
 
+    private final SSLContext sslContext;
+    private final SSLParameters sslParameters;
+
     private final HttpClient client;
 
     public RemotePayloadProcessor(URI uri) {
+        this(uri, null, null);
+    }
+
+    public RemotePayloadProcessor(URI uri, SSLContext sslContext, SSLParameters sslParameters) {
         this.uri = uri;
-        this.client = HttpClient.newHttpClient();
+        this.sslContext = sslContext;
+        this.sslParameters = sslParameters;
+        if (sslContext != null && sslParameters != null) {
+            this.client = HttpClient.newBuilder()
+                    .sslContext(sslContext)
+                    .sslParameters(sslParameters)
+                    .build();
+        } else {
+            this.client = HttpClient.newHttpClient();
+        }
     }
 
     @Override

--- a/src/test/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessorTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessorTest.java
@@ -16,7 +16,9 @@
 
 package com.ibm.watson.modelmesh.payload;
 
+import java.io.IOException;
 import java.net.URI;
+import java.security.NoSuchAlgorithmException;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -24,22 +26,45 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class RemotePayloadProcessorTest {
 
+    void testDestinationUnreachable() throws IOException {
+        URI uri = URI.create("http://this-does-not-exist:123");
+        try (RemotePayloadProcessor remotePayloadProcessor = new RemotePayloadProcessor(uri)) {
+            String id = "123";
+            String modelId = "456";
+            String method = "predict";
+            Status kind = Status.INVALID_ARGUMENT;
+            Metadata metadata = new Metadata();
+            metadata.put(Metadata.Key.of("foo", Metadata.ASCII_STRING_MARSHALLER), "bar");
+            metadata.put(Metadata.Key.of("binary-bin", Metadata.BINARY_BYTE_MARSHALLER), "string".getBytes());
+            ByteBuf data = Unpooled.buffer(4);
+            Payload payload = new Payload(id, modelId, method, metadata, data, kind);
+            assertFalse(remotePayloadProcessor.process(payload));
+        }
+    }
+
     @Test
-    void testDestinationUnreachable() {
-        RemotePayloadProcessor remotePayloadProcessor = new RemotePayloadProcessor(URI.create("http://this-does-not-exist:123"));
-        String id = "123";
-        String modelId = "456";
-        String method = "predict";
-        Status kind = Status.INVALID_ARGUMENT;
-        Metadata metadata = new Metadata();
-        metadata.put(Metadata.Key.of("foo", Metadata.ASCII_STRING_MARSHALLER), "bar");
-        metadata.put(Metadata.Key.of("binary-bin", Metadata.BINARY_BYTE_MARSHALLER), "string".getBytes());
-        ByteBuf data = Unpooled.buffer(4);
-        Payload payload = new Payload(id, modelId, method, metadata, data, kind);
-        assertFalse(remotePayloadProcessor.process(payload));
+    void testDestinationUnreachableHTTPS() throws IOException, NoSuchAlgorithmException {
+        URI uri = URI.create("https://this-does-not-exist:123");
+        SSLContext sslContext = SSLContext.getDefault();
+        SSLParameters sslParameters = sslContext.getDefaultSSLParameters();
+        try (RemotePayloadProcessor remotePayloadProcessor = new RemotePayloadProcessor(uri, sslContext, sslParameters)) {
+            String id = "123";
+            String modelId = "456";
+            String method = "predict";
+            Status kind = Status.INVALID_ARGUMENT;
+            Metadata metadata = new Metadata();
+            metadata.put(Metadata.Key.of("foo", Metadata.ASCII_STRING_MARSHALLER), "bar");
+            metadata.put(Metadata.Key.of("binary-bin", Metadata.BINARY_BYTE_MARSHALLER), "string".getBytes());
+            ByteBuf data = Unpooled.buffer(4);
+            Payload payload = new Payload(id, modelId, method, metadata, data, kind);
+            assertFalse(remotePayloadProcessor.process(payload));
+        }
     }
 }


### PR DESCRIPTION
#### Motivation

See [RHOAIENG-4963](https://issues.redhat.com/browse/RHOAIENG-4963).

Currently, ModelMesh only supports HTTP payload processors (TLS-enable endpoints not supported).
However, the ModelMesh truststore is not available by default when building a TLS-enabled processor.

#### Modifications

- This PR adds the `https` protocol as a recognized one for payload processors
- If the payload processor is TLS-enabled (`https`), the ModelMesh truststore will be explicitly loaded in order to be used
- If the payload processor is _not_ TLS-enabled (`http`) ModelMesh will proceed as before this PR

#### Result

The TLS-enabled payload processor is able to use ModelMesh's certificates in the truststore to perform HTTPS requests.
