### PR TITLE
Updating outdated Kustomize syntax to be in line with Kustomize v5 syntax

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -19,21 +19,24 @@ resources:
   - deployment.yaml
   - networkpolicy.yaml
 
-vars:
-  - name: MM_SERVICE_NAME
-    objref:
-      kind: Service
+replacements:
+- source:
+    kind: Service
+    name: model-mesh
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Deployment
       name: model-mesh
-      apiVersion: v1
-    fieldref:
-      fieldpath: metadata.name
+    fieldPaths:
+    - spec.template.spec.containers.0.env.[name=MM_SERVICE_NAME].value
 
 ### Available patches:
 
-#patchesStrategicMerge:
-#  - patches/etcd.yaml
-#  - patches/logger.yaml
-#  - patches/tls.yaml
-#  - patches/uds.yaml
-#  - patches/max_msg_size.yaml
-#  - patches/prometheus_metrics.yaml
+# patches:
+#  - path: patches/etcd.yaml
+#  - path: patches/logger.yaml
+#  - path: patches/tls.yaml
+#  - path: patches/uds.yaml
+#  - path: patches/max_msg_size.yaml
+#  - path: patches/prometheus_metrics.yaml


### PR DESCRIPTION
### Motivation
The main motivation for this update is to keep our manifests up to date with Kustomize v5. This ensures that we are using the latest syntax, which improves the compatibility and maintainability of our Kubernetes configurations.

### Modifications

#### 1. Replacements Section:
- Added a replacements section to dynamically change values in the deployment configuration.
- Corrected the field path to ensure the replacement does not break when patches are used.
- Specifically, it replaces the environment variable value in the model-mesh deployment with the service name.

**Old Syntax:**
```
vars:
  - name: MM_SERVICE_NAME
    objref:
      kind: Service
      name: model-mesh
      apiVersion: v1
    fieldref:
      fieldpath: metadata.name
```
**New Syntax:**
```
replacements:
- source:
    kind: Service
    name: model-mesh
    fieldPath: metadata.name
  targets:
  - select:
      kind: Deployment
      name: model-mesh
    fieldPaths:
    - spec.template.spec.containers.0.env.[name=MM_SERVICE_NAME].value
```
#### 2. Patch Paths:
- I updated the commented-out patches section to use the correct path syntax when they are needed.
```
# patches:
#  - path: patches/etcd.yaml
#  - path: patches/logger.yaml
#  - path: patches/tls.yaml
#  - path: patches/uds.yaml
#  - path: patches/max_msg_size.yaml
#  - path: patches/prometheus_metrics.yaml
```
### How I Tested
To ensure the correctness of these changes, the following steps were taken:

1. Ran the kustomize build command on the original manifests to produce the current state of the resources.
2. Updated to Kustomize v5 labels.
3. Ran the kustomize build command again on the updated manifests.
4. Compared the output of the kustomize build command from both the original and updated manifests.
5. Verified that there was no difference between the outputs.

Gist of all kustomize build pre-changes and post-changes: https://gist.github.com/KillianGolds/522e22734d547a90e69a619498ab71ca

### Result
These changes ensure that our Kustomize labels are up to date with version 5 syntax. Everything works as it should, with no changes to functionality other than updated syntax and corrected field paths for replacements and patches.

