### PR TITLE
Odh v2.32 release

### DIFF
--- a/.tekton/odh-modelmesh-push.yaml
+++ b/.tekton/odh-modelmesh-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/modelmesh:odh-v2.32
+    value: quay.io/opendatahub/modelmesh:odh-v2.33
   - name: dockerfile
     value: Dockerfile
   - name: path-context


### PR DESCRIPTION
Update Tekton output-image tags to version odh-v2.33
[RHOAIENG-29332]