### PR TITLE
[RHOAIENG-35143] CVE-2025-57852: Openshift-ai: privilege escalation v…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,9 +115,6 @@ RUN --mount=type=cache,target=/root/.cache/microdnf:rw \
     # Create app user
     && useradd -c "Application User" -U -u ${USER} -m app \
     && chown -R app:0 /home/app \
-    # Adjust permissions on /etc/passwd to be writable by group root.
-    # The user app is replaced by the assigned UID on OpenShift.
-    && chmod g+w /etc/passwd \
     # In newer Docker there is a --chown option for the COPY command
     && ln -s /opt/kserve/mmesh /opt/kserve/tas \
     && mkdir -p log \


### PR DESCRIPTION
…ia excessive /etc/passwd permissions

chore:  Fix [CVE-2025-57852](https://www.cve.org/CVERecord?id=CVE-2025-57852)

#### Motivation


#### Modifications


#### Result


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Hardened container image by removing a step that granted group write access to a system user registry file, aligning with least-privilege best practices.
  - Reduces potential security risk and improves compliance posture without altering app features or workflows.
  - No impact on performance or functionality; build and runtime behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->