### PR TITLE
CVE-2026-24281: bump ZooKeeper to 3.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <bouncycastle-version>1.78</bouncycastle-version>
     <junit-version>5.10.2</junit-version>
 
-    <zookeeper-version>3.8.4</zookeeper-version>
+    <zookeeper-version>3.8.6</zookeeper-version>
     <curator-version>5.3.0</curator-version>
 
     <dockerhome>${project.build.directory}/dockerhome</dockerhome>


### PR DESCRIPTION
## Summary
- Bump `org.apache.zookeeper:zookeeper` from 3.8.4 to 3.8.6
- Fixes CVE-2026-24281: hostname verification bypass via reverse DNS fallback in ZKTrustManager

## References
- https://nvd.nist.gov/vuln/detail/CVE-2026-24281
- https://zookeeper.apache.org/releases.html
- Upstream PR: https://github.com/kserve/modelmesh/pull/170