### PR TITLE
[RHOAIENG-55796] CVE-2026-33870: bump Netty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
     <grpc-version>1.63.2</grpc-version>
-    <netty-version>4.1.125.Final</netty-version>
+    <netty-version>4.1.132.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>
     <etcd-java-version>0.0.24</etcd-java-version>


### PR DESCRIPTION
## Summary
- Bump Netty from 4.1.125.Final to 4.1.132.Final to fix CVE-2026-33870
- Netty incorrectly parses quoted strings in HTTP/1.1 chunked transfer encoding extension values, enabling request smuggling attacks
- Fix versions: 4.1.132.Final and 4.2.10.Final

JIRA: https://issues.redhat.com/browse/RHOAIENG-55796
Upstream PR: https://github.com/kserve/modelmesh/pull/172

## Test plan
- [x] `mvn clean compile` — builds cleanly
- [x] `mvn clean test` — 69 tests, 1 pre-existing env error (TearDown), 0 failures
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)