### PR TITLE
[RHOAIENG-60265] CVE-2025-14813: bump BC to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
          since we have some custom optimized extensions to this -->
     <prometheus-version>0.9.0</prometheus-version>
 
-    <bouncycastle-version>1.78</bouncycastle-version>
+    <bouncycastle-version>1.84</bouncycastle-version>
     <junit-version>5.10.2</junit-version>
 
     <zookeeper-version>3.8.6</zookeeper-version>


### PR DESCRIPTION
## Summary
- Bump Bouncy Castle (`bcpkix-jdk18on`) from 1.78 to 1.84 to fix CVE-2025-14813
- GOSTCTR implementation unable to process more than 255 blocks correctly (affects BC-JAVA 1.59–1.84)
- modelmesh uses Bouncy Castle only for Netty TLS self-signed certs, so GOSTCTR is not in the execute path, but bumping resolves the scanner finding

## JIRA
https://redhat.atlassian.net/browse/RHOAIENG-60265

## Test plan
- [ ] Verify Maven build succeeds
- [ ] Verify unit tests pass
- [ ] Verify container image builds cleanly

Assisted-by: Claude Code (claude.ai/code)