### PR TITLE
[RHOAIENG-62801,RHOAIENG-62773] Bump Log4j to 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <!-- CVE-2026-43869: Apache Thrift security bypass due to improper certificate validation fixed in 0.23.0 -->
     <thrift-version>0.23.0</thrift-version>
     <eclipse-collections-version>11.1.0</eclipse-collections-version>
-    <log4j2-version>2.23.1</log4j2-version>
+    <log4j2-version>2.25.4</log4j2-version>
     <slf4j-version>1.7.36</slf4j-version>
     <javax-json-version>1.1.4</javax-json-version>
     <datadoghq-version>2.7</datadoghq-version>


### PR DESCRIPTION
## Summary
- Bump `org.apache.logging.log4j` from 2.23.1 to 2.25.4
- Fixes CVE-2026-34478: log injection via CRLF sequences in Rfc5424Layout (CVSS 7.5)
- Fixes CVE-2026-34480: invalid XML output causes DoS in XmlLayout (CVSS 7.5)

## Test plan
- [x] `mvn compile` passes
- [x] `mvn test` passes (1 pre-existing flaky teardown test unrelated to this change)

🤖 Generated with [Claude Code](https://claude.ai/code)