### PR TITLE
[RHOAIENG-72542] - CVE-2026-54512: jackson-databind: Arbitrary code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <protobuf-version>3.25.5</protobuf-version>
     <annotation-version>9.0.87</annotation-version>
     <guava-version>33.1.0-jre</guava-version>
-    <jackson-databind-version>2.16.2</jackson-databind-version>
+    <jackson-databind-version>2.18.8</jackson-databind-version>
     <gson-version>2.10.1</gson-version>
     <!-- CVE-2026-43869: Apache Thrift security bypass due to improper certificate validation fixed in 0.23.0 -->
     <thrift-version>0.23.0</thrift-version>


### PR DESCRIPTION
chore:  CVE-2026-54512 rhoai/odh-modelmesh-rhel9: jackson-databind: Arbitrary code execution via PolymorphicTypeValidator bypass

#### Motivation


#### Modifications


#### Result
