### PR TITLE
[RHOAIENG-68478] - CVE-2026-44249: netty-handler: IPv6 subnet rule by…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
     <grpc-version>1.63.2</grpc-version>
-    <netty-version>4.1.133.Final</netty-version>
+    <netty-version>4.1.135.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>
     <etcd-java-version>0.0.24</etcd-java-version>


### PR DESCRIPTION
…pass

chore:  CVE-2026-44249 rhoai/odh-modelmesh-rhel9: netty-handler: IPv6 subnet rule bypass due to incorrect masking operation

#### Motivation


#### Modifications


#### Result
